### PR TITLE
Add Extended string literal

### DIFF
--- a/xsharp-lang/syntaxes/xsharp.tmLanguage.json
+++ b/xsharp-lang/syntaxes/xsharp.tmLanguage.json
@@ -102,7 +102,7 @@
 		},
 		"interpolated-string-double": {
 			"name": "string.quoted.double.prg",
-			"begin": "(i|ie|ei|c)\"",
+			"begin": "(i|e|ie|ei|c)\"",
 			"end": "\"",
 			"patterns": [
 				{


### PR DESCRIPTION
### Aim

Add syntax to escape characters in extended string literals.


Previously characters wouldn't be escaped, which would cause everything afterwards to be considered a string.
![image](https://github.com/user-attachments/assets/b8eb021e-9f1c-44f4-8d9b-52b8af004b8e)

But with the recognition of extended string literals, it behaves as expected.

![image](https://github.com/user-attachments/assets/7414e7b5-dabb-4c07-b06f-3410d8d2e8dd)


### X# Help Documentation
![image](https://github.com/user-attachments/assets/d92a053e-f9f0-4558-a9b7-81376c0d03aa)

### Desployment notes

To help save some time, here are some observations from debugging this.

- May require an update to the version number in `package.json` if republishing
- The [old vscode extension package](https://www.npmjs.com/package/vsce) has been deprecated and the required version of Node for [the newer package](https://www.npmjs.com/package/@vscode/vsce) is v20.X.X
- Running `npx @vscode/vsce package` in the `xsharp-lang` directory will regenerate the `vsix` file
